### PR TITLE
add AstroFITS input/output

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,12 +7,21 @@ version = "0.2.4"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
+[weakdeps]
+AstroFITS = "34e54ef0-c5bf-48ab-9e5d-cca51f35ed77"
+FITSHeaders = "8163a04c-c153-4fb1-a498-3402381ec208"
+
+[extensions]
+MultivariateOnlineStatisticsAstroFITSExt = ["AstroFITS", "FITSHeaders"]
+
 [compat]
 StatsBase = "0.33, 0.34"
 julia = "1.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+AstroFITS = "34e54ef0-c5bf-48ab-9e5d-cca51f35ed77"
+FITSHeaders = "8163a04c-c153-4fb1-a498-3402381ec208"
 
 [targets]
-test = ["Test"]
+test = ["Test", "AstroFITS"]

--- a/ext/MultivariateOnlineStatisticsAstroFITSExt.jl
+++ b/ext/MultivariateOnlineStatisticsAstroFITSExt.jl
@@ -16,36 +16,36 @@ else
     import ..Base: read, write
 end
 
-function isa_stat_hdu(hdu)
+function MultivariateOnlineStatistics.isa_stat_hdu(hdu)
     (hdu isa AstroFITS.FitsImageHDU
      && haskey(hdu, STAT_HDU_KWD)
      && hdu[STAT_HDU_KWD].type == FITSHeaders.FITS_LOGICAL
      && hdu[STAT_HDU_KWD].logical)
 end
 
-function write(file::FitsFile, header::OptionalHeader, data::IndependentStatistics, args...)
+function Base.write(file::FitsFile, header::OptionalHeader, data::IndependentStatistics, args...)
     write(file, header, data)
     write(file, args...)
 end
 
-function write(file::FitsFile, hdr::OptionalHeader, stat::IndependentStatistics)
+function Base.write(file::FitsFile, hdr::OptionalHeader, stat::IndependentStatistics)
     write(merge!(FitsImageHDU(file, stat), hdr), stat)
     return file # returns the file not the HDU
 end
 
-FitsImageHDU(file::FitsFile, stat::IndependentStatistics{<:Any,T}) where {T} =
+AstroFITS.FitsImageHDU(file::FitsFile, stat::IndependentStatistics{<:Any,T}) where {T} =
     FitsImageHDU{T}(file, stat)
 
-FitsImageHDU{T}(file::FitsFile, stat::IndependentStatistics{<:Any,<:Any,N}) where {T,N} =
+AstroFITS.FitsImageHDU{T}(file::FitsFile, stat::IndependentStatistics{<:Any,<:Any,N}) where {T,N} =
     FitsImageHDU{T,N+1}(file, stat)
 
-function FitsImageHDU{T,N1}(file::FitsFile,
+function AstroFITS.FitsImageHDU{T,N1}(file::FitsFile,
                             stat::IndependentStatistics{<:Any,<:Any,N}) where {T,N1,N}
     N1 == N+1 || dimension_mismatch("HDU has $N1 dimensions instead of $(N+1)")
     return FitsImageHDU{T,N1}(file, (size(stat)..., order(stat)))
 end
 
-function write(hdu::FitsImageHDU{<:Any,N1},
+function Base.write(hdu::FitsImageHDU{<:Any,N1},
                stat::IndependentStatistics{L,T,N}) where {N1,L,T,N}
     N1 == N+1 || dimension_mismatch("HDU has $N1 dimensions instead of $(N+1)")
 
@@ -66,19 +66,19 @@ end
 
 
 
-read(::Type{IndependentStatistics}, hdu::FitsImageHDU; kwds...) =
+Base.read(::Type{IndependentStatistics}, hdu::FitsImageHDU; kwds...) =
     read(IndependentStatistics{hdu.data_size[end]}, hdu; kwds...)
 
-read(::Type{IndependentStatistics{L}}, hdu::FitsImageHDU{T}; kwds...) where {L,T} =
+Base.read(::Type{IndependentStatistics{L}}, hdu::FitsImageHDU{T}; kwds...) where {L,T} =
     read(IndependentStatistics{L,T}, hdu; kwds...)
 
-read(::Type{IndependentStatistics{L,T}}, hdu::FitsImageHDU{<:Any,N1}; kwds...) where {L,T,N1} =
+Base.read(::Type{IndependentStatistics{L,T}}, hdu::FitsImageHDU{<:Any,N1}; kwds...) where {L,T,N1} =
     read(IndependentStatistics{L,T,N1-1}, hdu; kwds...)
 
-read(::Type{IndependentStatistics{L,T,N}}, hdu::FitsImageHDU; kwds...) where {L,T,N} =
+Base.read(::Type{IndependentStatistics{L,T,N}}, hdu::FitsImageHDU; kwds...) where {L,T,N} =
     read(IndependentStatistics{L,T,N,Array{T,N}}, hdu; kwds...)
 
-function read(::Type{IndependentStatistics{L,T,N,A}},
+function Base.read(::Type{IndependentStatistics{L,T,N,A}},
               hdu::FitsImageHDU{<:Any,N1}; kwds...) where {L,T,N,A,N1}
     N1 == N+1 || dimension_mismatch("HDU has $N1 dimensions instead of $(N+1)")
 

--- a/ext/MultivariateOnlineStatisticsAstroFITSExt.jl
+++ b/ext/MultivariateOnlineStatisticsAstroFITSExt.jl
@@ -1,0 +1,103 @@
+module MultivariateOnlineStatisticsAstroFITSExt
+
+if isdefined(Base, :get_extension)
+    using MultivariateOnlineStatistics, AstroFITS, FITSHeaders
+    using MultivariateOnlineStatistics:
+        argument_error, dimension_mismatch, STAT_HDU_KWD, STAT_NB_SAMPLES_KWD
+    import MultivariateOnlineStatistics: isa_stat_hdu
+    import AstroFITS: FitsImageHDU, OptionalHeader
+    import Base: read, write
+else
+    using ..MultivariateOnlineStatistics, ..AstroFITS, ..FITSHeaders
+    using ..MultivariateOnlineStatistics:
+        argument_error, dimension_mismatch, STAT_HDU_KWD, STAT_NB_SAMPLES_KWD
+    import ..MultivariateOnlineStatistics: isa_stat_hdu
+    import ..AstroFITS: FitsImageHDU, OptionalHeader
+    import ..Base: read, write
+end
+
+function isa_stat_hdu(hdu)
+    (hdu isa AstroFITS.FitsImageHDU
+     && haskey(hdu, STAT_HDU_KWD)
+     && hdu[STAT_HDU_KWD].type == FITSHeaders.FITS_LOGICAL
+     && hdu[STAT_HDU_KWD].logical)
+end
+
+function write(file::FitsFile, header::OptionalHeader, data::IndependentStatistics, args...)
+    write(file, header, data)
+    write(file, args...)
+end
+
+function write(file::FitsFile, hdr::OptionalHeader, stat::IndependentStatistics)
+    write(merge!(FitsImageHDU(file, stat), hdr), stat)
+    return file # returns the file not the HDU
+end
+
+FitsImageHDU(file::FitsFile, stat::IndependentStatistics{<:Any,T}) where {T} =
+    FitsImageHDU{T}(file, stat)
+
+FitsImageHDU{T}(file::FitsFile, stat::IndependentStatistics{<:Any,<:Any,N}) where {T,N} =
+    FitsImageHDU{T,N+1}(file, stat)
+
+function FitsImageHDU{T,N1}(file::FitsFile,
+                            stat::IndependentStatistics{<:Any,<:Any,N}) where {T,N1,N}
+    N1 == N+1 || dimension_mismatch("HDU has $N1 dimensions instead of $(N+1)")
+    return FitsImageHDU{T,N1}(file, (size(stat)..., order(stat)))
+end
+
+function write(hdu::FitsImageHDU{<:Any,N1},
+               stat::IndependentStatistics{L,T,N}) where {N1,L,T,N}
+    N1 == N+1 || dimension_mismatch("HDU has $N1 dimensions instead of $(N+1)")
+
+    hdu.data_size == (size(stat)..., order(stat)) || dimension_mismatch(
+        "HDU size is $(hdu.data_size) instead of $((size(stat)..., order(stat)))")
+
+    push!(hdu, STAT_HDU_KWD        => (true,   "image is IndependentStatistics data"),
+               STAT_NB_SAMPLES_KWD => (stat.n, "number of statistical samples"))
+
+    i = 1
+    for l in 1:L
+        write(hdu, stat.s[l]; first=i)
+        i += length(stat)
+    end
+
+    return hdu
+end
+
+
+
+read(::Type{IndependentStatistics}, hdu::FitsImageHDU; kwds...) =
+    read(IndependentStatistics{hdu.data_size[end]}, hdu; kwds...)
+
+read(::Type{IndependentStatistics{L}}, hdu::FitsImageHDU{T}; kwds...) where {L,T} =
+    read(IndependentStatistics{L,T}, hdu; kwds...)
+
+read(::Type{IndependentStatistics{L,T}}, hdu::FitsImageHDU{<:Any,N1}; kwds...) where {L,T,N1} =
+    read(IndependentStatistics{L,T,N1-1}, hdu; kwds...)
+
+read(::Type{IndependentStatistics{L,T,N}}, hdu::FitsImageHDU; kwds...) where {L,T,N} =
+    read(IndependentStatistics{L,T,N,Array{T,N}}, hdu; kwds...)
+
+function read(::Type{IndependentStatistics{L,T,N,A}},
+              hdu::FitsImageHDU{<:Any,N1}; kwds...) where {L,T,N,A,N1}
+    N1 == N+1 || dimension_mismatch("HDU has $N1 dimensions instead of $(N+1)")
+
+    L == hdu.data_size[N1] || dimension_mismatch(
+        "HDU has $(hdu.data_size[N1]) statistical moments instead of $L")
+    
+    haskey(hdu, STAT_NB_SAMPLES_KWD) || argument_error(
+        "HDU miss keyword \"$STAT_NB_SAMPLES_KWD\"")
+
+    hdu[STAT_NB_SAMPLES_KWD].type == FITSHeaders.FITS_INTEGER || argument_error(
+        "HDU keyword \"$STAT_NB_SAMPLES_KWD\" is not of type integer")
+
+    isa_stat_hdu(hdu) || @warn("HDU is not declared as IndependentStatistics data")
+
+    n = hdu[STAT_NB_SAMPLES_KWD].integer
+    data = read(Array{T,N1}, hdu; kwds...)
+    s = NTuple{L,A}( A(sl) for sl in eachslice(data; dims=N1))
+
+    return IndependentStatistics{L,T,N,A}(s,n)
+end
+
+end

--- a/src/MultivariateOnlineStatistics.jl
+++ b/src/MultivariateOnlineStatistics.jl
@@ -495,6 +495,17 @@ yields integer `x` converted to an `Int`.
 to_int(x::Int) = x
 to_int(x::Integer) = Int(x)
 
+
+# For AstroFITS input/output extension
+const STAT_HDU_KWD = "STAT-HDU"
+const STAT_NB_SAMPLES_KWD = "STAT-NB-SAMPLES"
+function isa_stat_hdu end # defined in the extension
+
+@noinline argument_error(args...) =
+    argument_error(string(args...))
+@noinline argument_error(mesg::AbstractString) =
+    throw(ArgumentError(mesg))
+
 @noinline dimension_mismatch(args...) = dimension_mismatch(string(args...))
 @noinline dimension_mismatch(msg::AbstractString) =
     throw(DimensionMismatch(msg))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,8 @@
 module TestingMultivariateOnlineStatistics
 
-using MultivariateOnlineStatistics, Test, Statistics, StatsBase
+using MultivariateOnlineStatistics, Test, Statistics, StatsBase, AstroFITS
 
-using MultivariateOnlineStatistics: storage
+using MultivariateOnlineStatistics: storage, STAT_HDU_KWD, STAT_NB_SAMPLES_KWD, isa_stat_hdu
 
 # Dummy private function used to "label" the tests.
 check(flag::Bool, comment) = flag
@@ -220,6 +220,91 @@ check(flag::Bool, comment) = flag
         @test order(B) == order(A)
         @test eltype(B) == eltype(A)
         @test size(B) == size(A)
+    end
+
+    # AstroFITS extension (input/output)
+    mktempdir() do dir
+
+        # prepare some initial stat to work with
+        p = normpath(dir, "test.fits")
+        (W,H,S) = (4,7,15)
+        rawdata = rand(W,H,S)
+        (L,T,N) = (2, Float64, 2)
+        A = Array{T,N}
+        stat = merge!(IndependentStatistics{L,T,N}(W,H), eachslice(rawdata; dims=3))
+        hdr = FitsHeader("TEST" => 42)
+        
+        # test writing on path
+        @test_nowarn writefits!(p, hdr, stat)
+        
+        # test writing on FitsFile
+        FitsFile(p, "w!") do f
+            @test write(f, hdr, stat)[1].data_eltype == T
+            @test f[1].data_size == (W,H,L)
+            @test isa_stat_hdu(f[1])
+        end
+
+        # test FitsImageHDU declaration
+        FitsFile(p, "w!") do f
+            @test FitsImageHDU(f, stat).data_eltype == T
+            @test FitsImageHDU(f, stat).data_size == (W,H,L)
+            @test FitsImageHDU{T}(f, stat).data_eltype == T
+            @test FitsImageHDU{T}(f, stat).data_size == (W,H,L)
+            @test FitsImageHDU{Float32}(f, stat).data_eltype == Float32
+            @test FitsImageHDU{Float32}(f, stat).data_size == (W,H,L)
+            @test FitsImageHDU{T,3}(f, stat).data_size == (W,H,L)
+            msg = "HDU has 4 dimensions instead of $(N+1)"
+            @test_throws DimensionMismatch(msg) FitsImageHDU{T,4}(f, stat)
+        end
+
+        # test writing on FitsImageHDU
+        FitsFile(p, "w!") do f
+            hdu = FitsImageHDU(f, stat)
+            @test write(hdu, stat).data_eltype == T
+            @test write(hdu, stat).data_size == (W,H,L)
+            hdu = FitsImageHDU{T,2}(f, (W,H))
+            msg = "HDU has 2 dimensions instead of $(N+1)"
+            @test_throws DimensionMismatch(msg) write(hdu, stat)
+            hdu = FitsImageHDU{T,3}(f, (W,H,3))
+            msg = "HDU size is $((W,H,3)) instead of $((W,H,L))"
+            @test_throws DimensionMismatch(msg) write(hdu, stat)
+        end
+        
+        # test reading of statistical HDU and equality to our initial stat 
+        writefits!(p, hdr, stat)
+        @test readfits(IndependentStatistics, p).s == stat.s
+        @test readfits(IndependentStatistics, p).n == stat.n
+        FitsFile(p, "r") do f
+            hdu = f[1]
+            @test hdu["TEST"].integer == 42
+            @test read(IndependentStatistics, hdu).n == stat.n
+            @test read(IndependentStatistics{L}, hdu).n == stat.n
+            @test read(IndependentStatistics{L,T}, hdu).n == stat.n
+            @test read(IndependentStatistics{L,T,N}, hdu).n == stat.n
+            @test read(IndependentStatistics{L,T,N,A}, hdu).n == stat.n
+            msg = "HDU has $L statistical moments instead of 3"
+            @test_throws DimensionMismatch(msg) read(IndependentStatistics{3}, hdu)
+            msg = "HDU has $(N+1) dimensions instead of 4"
+            @test_throws DimensionMismatch(msg) read(IndependentStatistics{L,T,3}, hdu)
+            @test_throws TypeError read(IndependentStatistics{L,T,N,Vector{T}}, hdu)
+        end
+        
+        # test absence or wrongness of STAT HDU keywords
+        writefits!(p, hdr, stat)
+        FitsFile(p, "rw") do f
+            hdu = f[1]
+            delete!(hdu, STAT_HDU_KWD)
+            msg = "HDU is not declared as IndependentStatistics data"
+            @test_warn msg read(IndependentStatistics, hdu)
+            
+            hdu[STAT_NB_SAMPLES_KWD] = "wrong"
+            msg = "HDU keyword \"$STAT_NB_SAMPLES_KWD\" is not of type integer"
+            @test_throws ArgumentError(msg) read(IndependentStatistics, hdu)
+            
+            delete!(hdu, STAT_NB_SAMPLES_KWD)
+            msg = "HDU miss keyword \"$STAT_NB_SAMPLES_KWD\""
+            @test_throws ArgumentError(msg) read(IndependentStatistics, hdu)
+        end
     end
 end
 


### PR DESCRIPTION
- permits to store the Independent Statistics as a FITS file with the help of AstroFITS package
- statistical moments are simply stacked into a FItsImageHDU. A keyword is used to store the number of samples.
- actual code is very small ;
- most of the code is : taking care of proposing the same constructors as AstroFITS and MultivariateOnlineStatistics do, with the types more or less declared or automatically chosen.
- complete (I hope) testing
- "tricky" part is to check carefully that the HDU has one dimension more than the data samples HDU (the additional dimension is for the statistical moments)